### PR TITLE
Upgrade to Laravel 13.7 (Wave 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor
+/.idea
+composer.phar
+composer.lock
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # df-git
 
 BitBucket, GitHub, and GitLab services for DreamFactory Platform
+
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,35 @@
   },
   "minimum-stability": "dev",
   "prefer-stable":     true,
+  "repositories": [
+    {
+      "type": "vcs",
+      "url":  "https://github.com/Stichoza/Laravel-GitHub"
+    },
+    {
+      "type": "vcs",
+      "url":  "https://github.com/Infomaniak/Laravel-GitLab"
+    },
+    {
+      "type": "vcs",
+      "url":  "https://github.com/broqit/Laravel-Bitbucket"
+    }
+  ],
   "require":     {
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
     "dreamfactory/df-core": "~1.0.4",
-    "graham-campbell/github": "^12.6",
-    "graham-campbell/gitlab": "^7.5",
-    "graham-campbell/bitbucket": "^10.4",
+    "graham-campbell/github": "13.0.x-dev",
+    "graham-campbell/gitlab": "dev-add-laravel-13",
+    "graham-campbell/bitbucket": "11.0.x-dev",
     "php-http/guzzle7-adapter": "^1.0.0"
+  },
+  "require-dev": {
+    "laravel/framework":    "^13.7",
+    "mockery/mockery":      "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit":      "^11.5.3",
+    "orchestra/testbench":  "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Components/GitLabClient.php
+++ b/src/Components/GitLabClient.php
@@ -6,23 +6,7 @@ use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use DreamFactory\Core\Git\Contracts\ClientInterface;
 use GrahamCampbell\GitLab\Auth\AuthenticatorFactory;
 use Gitlab\Client;
-use Gitlab\Api\Users;
 use Illuminate\Support\Arr;
-
-class CustomUsers extends Users
-{
-    /**
-     * @param int $id
-     * @param array $params
-     * @return mixed
-     */
-    public function usersProjects($id, array $params = [])
-    {
-        $resolver = $this->createOptionsResolver();
-
-        return $this->get('users/' . $this->encodePath($id) . '/projects', $resolver->resolve($params));
-    }
-}
 
 class GitLabClient implements ClientInterface
 {
@@ -32,6 +16,9 @@ class GitLabClient implements ClientInterface
 
     /** @var string */
     protected $namespace;
+
+    /** @var int|null */
+    protected $userId;
 
     /**
      * GitLabClient constructor.
@@ -58,6 +45,7 @@ class GitLabClient implements ClientInterface
                 throw new InternalServerErrorException('No authenticated user found for GitLab client. Please check GitLab service configuration.');
             }
             $namespace = $userInfo['username'];
+            $this->userId = isset($userInfo['id']) ? (int) $userInfo['id'] : null;
         }
         $this->namespace = $namespace;
     }
@@ -90,17 +78,20 @@ class GitLabClient implements ClientInterface
     /** {@inheritdoc} */
     public function repoAll($page = 1, $perPage = 50)
     {
-        $username = $this->client->users()->me()['username'];
+        $userInfo = $this->client->users()->me();
+        $username = $userInfo['username'] ?? null;
         $params = ['page' => (int)$page, 'per_page' => (int)$perPage];
 
         if ($username !== $this->namespace) {
             $groupList = $this->client->groups()->projects(rawurlencode($this->namespace), $params);
             return $groupList;
-        } else {
-            $cu = new CustomUsers($this->client);
-            $userList = $cu->usersProjects($username, $params);
-            return $userList;
         }
+
+        $userId = $this->userId ?? (isset($userInfo['id']) ? (int) $userInfo['id'] : null);
+        if ($userId === null) {
+            throw new InternalServerErrorException('Unable to determine GitLab user id for projects lookup.');
+        }
+        return $this->client->users()->usersProjects($userId, $params);
     }
 
     /** {@inheritdoc} */


### PR DESCRIPTION
## Summary

- Bump `require-dev` to Laravel 13.7 / PHPUnit 11.5 / Orchestra Testbench 11.0 — the same matrix landed in df-core (#162), df-system, df-user, df-database, and df-sqldb.
- Add `laravel/helpers ^1.8` and `php ^8.3` to runtime `require` to align with the Wave-0/1 base packages.
- **Bitbucket / GitHub / GitLab dependency rework** (the reason this is the Wave 4 high-risk package). All three `graham-campbell/{bitbucket,github,gitlab}` Laravel wrappers currently cap at `illuminate/support: ^10.44 || ^11.0 || ^12.0` on Packagist — none of them have tagged Laravel 13 support yet. The underlying SDK clients (`bitbucket/client` 5.x, `knplabs/github-api` 3.x, `m4tthumphrey/php-gitlab-api` 12.x) are framework-agnostic, so the only blocker is the wrapper service providers / authenticator factories.
  - There are open community PRs that already widen the constraint to `^13.0` against forks: [Stichoza/Laravel-GitHub#13.0](https://github.com/GrahamCampbell/Laravel-GitHub/pull/168), [Infomaniak/Laravel-GitLab#add-laravel-13](https://github.com/GrahamCampbell/Laravel-GitLab/pull/53), [broqit/Laravel-Bitbucket#11.0](https://github.com/GrahamCampbell/Laravel-Bitbucket/pull/41). Until those upstream PRs are merged, this PR pins the three wrappers to the community fork branches via `repositories[]` VCS entries.
  - When the upstream PRs land, the swap-back is mechanical: replace the three VCS repositories with the canonical `^13.0` / `^9.0` / `^12.0` tags and re-bump.
- **GitLab API source patch.** `m4tthumphrey/php-gitlab-api` 12.0 added `Users::usersProjects(int $id, array $parameters = []): mixed` natively. The local `CustomUsers` shim that used to provide this method had a loose `($id, array $params = [])` signature that now fails the LSP check at autoload time. Drop the shim and call `users()->usersProjects($userId, $params)` directly, capturing the integer user id from `users()->me()['id']` during construction (only when no namespace was provided in config — preserving the original lazy-fetch behavior).
- Add `.gitignore` matching the rest of the L13 base packages.

## Validation

**Stage 1 — isolated install.** `composer install --no-dev` resolves under L13 with df-core / df-system path-repo aliases. A `class_exists()` smoke check passes 22/22 namespaced classes (df-git's own + the three `GrahamCampbell\*\Auth\AuthenticatorFactory` + the three SDK `Client` classes) under `Illuminate\Foundation\Application::VERSION === '13.7.0'`.

**Stage 2 — host-app integration.** `composer install --no-dev` against the `shift-173254` host-app worktree resolves cleanly with df-git symlinked from this branch. df-git is **NOT on the strip-list** for this stage. 13/13 public classes load under L13.7.0 + PHP 8.3.17. **Once this PR merges, df-git can be removed from the Wave 1+ Stage-2 sibling-blocker strip-list (it has been the second-worst offender after df-mongo-logs).**

## Test plan

- [x] `composer validate --no-check-publish`
- [x] `php -l` clean across all 12 PHP source files
- [x] Stage-1 isolated install + 22/22 class_exists smoke
- [x] Stage-2 host-app install + 13/13 class_exists smoke
- [ ] Functional test against a live GitLab/GitHub/Bitbucket service (deferred to host-app L13 cut-over)
- [ ] Swap VCS forks back to canonical packagist releases once Stichoza/Laravel-GitHub#168, GrahamCampbell/Laravel-GitLab#53, and GrahamCampbell/Laravel-Bitbucket#41 are merged