### PR TITLE
Use repository default branch when no ref is given; document branch p…

### DIFF
--- a/src/Components/BitbucketClient.php
+++ b/src/Components/BitbucketClient.php
@@ -82,6 +82,23 @@ class BitbucketClient implements GitClientInterface
     }
 
     /**
+     * Falls back to the repository's main branch when no ref is provided.
+     *
+     * @param string      $repo
+     * @param string|null $ref
+     *
+     * @return string
+     */
+    protected function resolveRef($repo, $ref)
+    {
+        if (!empty($ref)) {
+            return $ref;
+        }
+
+        return Arr::get($this->workspace->show($repo), 'mainbranch.name');
+    }
+
+    /**
      * @param int $page
      * @param int $perPage
      *
@@ -126,6 +143,7 @@ class BitbucketClient implements GitClientInterface
     public function repoGetFileInfo($repo, $path, $ref = null)
     {
         $src = new CustomSrc($this->client, $this->username, $repo);
+        $ref = $this->resolveRef($repo, $ref);
 
         $result = $src->show($ref, $path);
         if ('commit_directory' === $result['type']) {
@@ -154,6 +172,7 @@ class BitbucketClient implements GitClientInterface
     public function repoGetFileContent($repo, $path, $ref = null)
     {
         $src = new CustomSrc($this->client, $this->username, $repo);
+        $ref = $this->resolveRef($repo, $ref);
 
         $result = $src->show($ref, $path);
 

--- a/src/Components/GitLabClient.php
+++ b/src/Components/GitLabClient.php
@@ -73,6 +73,23 @@ class GitLabClient implements ClientInterface
     }
 
     /**
+     * Falls back to the project's default branch when no ref is provided.
+     *
+     * @param string      $repo
+     * @param string|null $ref
+     *
+     * @return string
+     */
+    protected function resolveRef($repo, $ref)
+    {
+        if (!empty($ref)) {
+            return $ref;
+        }
+
+        return Arr::get($this->client->projects()->show($this->getProjectId($repo)), 'default_branch');
+    }
+
+    /**
      * @param $config
      *
      * @throws \DreamFactory\Core\Exceptions\InternalServerErrorException
@@ -114,7 +131,7 @@ class GitLabClient implements ClientInterface
     {
         $result = $this->repoList($repo, $path, $ref);
         if (0 === count($result)) {
-            $result = $this->client->repositoryFiles()->getFile($this->getProjectId($repo), $path, $ref);
+            $result = $this->client->repositoryFiles()->getFile($this->getProjectId($repo), $path, $this->resolveRef($repo, $ref));
             $result['path'] = $result['file_path'];
         }
 
@@ -124,7 +141,7 @@ class GitLabClient implements ClientInterface
     /** {@inheritdoc} */
     public function repoGetFileContent($repo, $path = null, $ref = null)
     {
-        return $this->client->repositoryFiles()->getRawFile($this->getProjectId($repo), $path, $ref);
+        return $this->client->repositoryFiles()->getRawFile($this->getProjectId($repo), $path, $this->resolveRef($repo, $ref));
     }
 
 }

--- a/src/Resources/BaseResource.php
+++ b/src/Resources/BaseResource.php
@@ -31,7 +31,7 @@ class BaseResource extends BaseRestResource
      */
     protected function handleGET()
     {
-        $branch = $this->request->getParameter('branch', $this->request->getParameter('tag', 'master'));
+        $branch = $this->request->getParameter('branch', $this->request->getParameter('tag'));
         $getContent = $this->request->getParameterAsBool('content');
         $asList = $this->request->getParameterAsBool(ApiOptions::AS_LIST);
         $fields = $this->request->getParameter(ApiOptions::FIELDS, '*');
@@ -125,6 +125,12 @@ class BaseResource extends BaseRestResource
                             'schema'      => ['type' => 'string'],
                             'description' => 'A file/folder path'
                         ],
+                        [
+                            'name'        => 'branch',
+                            'in'          => 'query',
+                            'schema'      => ['type' => 'string'],
+                            'description' => 'Branch or tag name. If omitted, the repository\'s default branch is used.'
+                        ],
                         ApiOptions::documentOption(ApiOptions::AS_LIST),
                     ],
                     'responses'   => [
@@ -157,6 +163,12 @@ class BaseResource extends BaseRestResource
                             'in'          => 'query',
                             'schema'      => ['type' => 'boolean'],
                             'description' => 'Set true to get file content',
+                        ],
+                        [
+                            'name'        => 'branch',
+                            'in'          => 'query',
+                            'schema'      => ['type' => 'string'],
+                            'description' => 'Branch or tag name. If omitted, the repository\'s default branch is used.'
                         ],
                     ],
                     'responses'   => [


### PR DESCRIPTION
…arameter

The _repo resource hardcoded 'master' as the default ref, so any repository whose default branch is not 'master' (e.g. 'main', GitHub's default since 2020) returned 404 'No commit found for the ref master' on every request that omitted the branch parameter.

- BaseResource: default ref is now null instead of 'master'
- GitHub: KnpLabs client strips a null ref, so the GitHub API serves the repository's default branch natively
- GitLab: resolve the project's default_branch for getFile/getRawFile, which require a string ref; tree listing already defaults server-side
- Bitbucket: resolve mainbranch.name for src lookups, which embed the ref in the URI path
- API docs: add the 'branch' query parameter to GET /_repo/{repo_name} and GET /_repo/{repo_name}/{path} for all three git service types