### PR TITLE
7.7: use upstream graham-campbell gitlab + bitbucket, drop remaining forks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,23 +33,14 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/Infomaniak/Laravel-GitLab"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/broqit/Laravel-Bitbucket"
-        }
-    ],
+    "repositories": [],
     "require": {
         "php": "^8.3",
         "laravel/helpers": "^1.8",
         "dreamfactory/df-core": "~1.0.4",
         "graham-campbell/github": "^13.1",
-        "graham-campbell/gitlab": "dev-add-laravel-13",
-        "graham-campbell/bitbucket": "11.0.x-dev",
+        "graham-campbell/gitlab": "^8.1",
+        "graham-campbell/bitbucket": "^11.1",
         "php-http/guzzle7-adapter": "^1.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
Follow-up to #42 (which fixed the github fork). df-git also pinned graham-campbell/gitlab and graham-campbell/bitbucket to fork branches as Laravel 13 stopgaps. Upstream has caught up (gitlab v8.1.1, bitbucket v11.1.0 both support illuminate/support ^13.0), so this bumps to `^8.1` / `^11.1` and removes the two remaining fork `repositories` entries. df-git now has zero fork dependencies. Verified all three resolve clean under Laravel 13.