### PR TITLE
release: 7.7.0 — develop → master cut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor
+/.idea
+composer.phar
+composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -33,23 +33,14 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/Infomaniak/Laravel-GitLab"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/broqit/Laravel-Bitbucket"
-        }
-    ],
+    "repositories": [],
     "require": {
         "php": "^8.3",
         "laravel/helpers": "^1.8",
         "dreamfactory/df-core": "~1.0.4",
         "graham-campbell/github": "^13.1",
-        "graham-campbell/gitlab": "dev-add-laravel-13",
-        "graham-campbell/bitbucket": "11.0.x-dev",
+        "graham-campbell/gitlab": "^8.1",
+        "graham-campbell/bitbucket": "^11.1",
         "php-http/guzzle7-adapter": "^1.0.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,81 +1,77 @@
 {
-  "name":        "dreamfactory/df-git",
-  "description": "Git services for DreamFactory Platform 2.0",
-  "keywords":    [
-    "dreamfactory",
-    "api",
-    "rest",
-    "git",
-    "github",
-    "gitlab",
-    "version",
-    "scm",
-    "source",
-    "version"
-  ],
-  "homepage":    "https://www.dreamfactory.com/",
-  "license":     "proprietary",
-  "authors":     [
-    {
-      "name":  "Arif Islam",
-      "email": "arifislam@dreamfactory.com"
+    "name": "dreamfactory/df-git",
+    "description": "Git services for DreamFactory Platform 2.0",
+    "keywords": [
+        "dreamfactory",
+        "api",
+        "rest",
+        "git",
+        "github",
+        "gitlab",
+        "version",
+        "scm",
+        "source",
+        "version"
+    ],
+    "homepage": "https://www.dreamfactory.com/",
+    "license": "proprietary",
+    "authors": [
+        {
+            "name": "Arif Islam",
+            "email": "arifislam@dreamfactory.com"
+        },
+        {
+            "name": "Lee Hicks",
+            "email": "leehicks@dreamfactory.com"
+        }
+    ],
+    "support": {
+        "email": "dspsupport@dreamfactory.com",
+        "source": "https://github.com/dreamfactorysoftware/df-git",
+        "issues": "https://github.com/dreamfactorysoftware/df-git/issues",
+        "wiki": "https://wiki.dreamfactory.com"
     },
-    {
-      "name":  "Lee Hicks",
-      "email": "leehicks@dreamfactory.com"
-    }
-  ],
-  "support":     {
-    "email":  "dspsupport@dreamfactory.com",
-    "source": "https://github.com/dreamfactorysoftware/df-git",
-    "issues": "https://github.com/dreamfactorysoftware/df-git/issues",
-    "wiki":   "https://wiki.dreamfactory.com"
-  },
-  "minimum-stability": "dev",
-  "prefer-stable":     true,
-  "repositories": [
-    {
-      "type": "vcs",
-      "url":  "https://github.com/Stichoza/Laravel-GitHub"
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/Infomaniak/Laravel-GitLab"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/broqit/Laravel-Bitbucket"
+        }
+    ],
+    "require": {
+        "php": "^8.3",
+        "laravel/helpers": "^1.8",
+        "dreamfactory/df-core": "~1.0.4",
+        "graham-campbell/github": "^13.1",
+        "graham-campbell/gitlab": "dev-add-laravel-13",
+        "graham-campbell/bitbucket": "11.0.x-dev",
+        "php-http/guzzle7-adapter": "^1.0.0"
     },
-    {
-      "type": "vcs",
-      "url":  "https://github.com/Infomaniak/Laravel-GitLab"
+    "require-dev": {
+        "laravel/framework": "^13.7",
+        "mockery/mockery": "^1.6",
+        "nunomaduro/collision": "^8.6",
+        "phpunit/phpunit": "^11.5.3",
+        "orchestra/testbench": "^11.0"
     },
-    {
-      "type": "vcs",
-      "url":  "https://github.com/broqit/Laravel-Bitbucket"
-    }
-  ],
-  "require":     {
-    "php": "^8.3",
-    "laravel/helpers": "^1.8",
-    "dreamfactory/df-core": "~1.0.4",
-    "graham-campbell/github": "13.0.x-dev",
-    "graham-campbell/gitlab": "dev-add-laravel-13",
-    "graham-campbell/bitbucket": "11.0.x-dev",
-    "php-http/guzzle7-adapter": "^1.0.0"
-  },
-  "require-dev": {
-    "laravel/framework":    "^13.7",
-    "mockery/mockery":      "^1.6",
-    "nunomaduro/collision": "^8.6",
-    "phpunit/phpunit":      "^11.5.3",
-    "orchestra/testbench":  "^11.0"
-  },
-  "autoload":    {
-    "psr-4": {
-      "DreamFactory\\Core\\Git\\": "src/"
-    }
-  },
-  "extra":       {
-    "branch-alias": {
-      "dev-develop": "0.3.x-dev"
+    "autoload": {
+        "psr-4": {
+            "DreamFactory\\Core\\Git\\": "src/"
+        }
     },
-    "laravel": {
-      "providers": [
-        "DreamFactory\\Core\\Git\\ServiceProvider"
-      ]
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "0.3.x-dev"
+        },
+        "laravel": {
+            "providers": [
+                "DreamFactory\\Core\\Git\\ServiceProvider"
+            ]
+        }
     }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,35 @@
   },
   "minimum-stability": "dev",
   "prefer-stable":     true,
+  "repositories": [
+    {
+      "type": "vcs",
+      "url":  "https://github.com/Stichoza/Laravel-GitHub"
+    },
+    {
+      "type": "vcs",
+      "url":  "https://github.com/Infomaniak/Laravel-GitLab"
+    },
+    {
+      "type": "vcs",
+      "url":  "https://github.com/broqit/Laravel-Bitbucket"
+    }
+  ],
   "require":     {
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
     "dreamfactory/df-core": "~1.0.4",
-    "graham-campbell/github": "^12.6",
-    "graham-campbell/gitlab": "^7.5",
-    "graham-campbell/bitbucket": "^10.4",
+    "graham-campbell/github": "13.0.x-dev",
+    "graham-campbell/gitlab": "dev-add-laravel-13",
+    "graham-campbell/bitbucket": "11.0.x-dev",
     "php-http/guzzle7-adapter": "^1.0.0"
+  },
+  "require-dev": {
+    "laravel/framework":    "^13.7",
+    "mockery/mockery":      "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit":      "^11.5.3",
+    "orchestra/testbench":  "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Components/BitbucketClient.php
+++ b/src/Components/BitbucketClient.php
@@ -82,6 +82,23 @@ class BitbucketClient implements GitClientInterface
     }
 
     /**
+     * Falls back to the repository's main branch when no ref is provided.
+     *
+     * @param string      $repo
+     * @param string|null $ref
+     *
+     * @return string
+     */
+    protected function resolveRef($repo, $ref)
+    {
+        if (!empty($ref)) {
+            return $ref;
+        }
+
+        return Arr::get($this->workspace->show($repo), 'mainbranch.name');
+    }
+
+    /**
      * @param int $page
      * @param int $perPage
      *
@@ -126,6 +143,7 @@ class BitbucketClient implements GitClientInterface
     public function repoGetFileInfo($repo, $path, $ref = null)
     {
         $src = new CustomSrc($this->client, $this->username, $repo);
+        $ref = $this->resolveRef($repo, $ref);
 
         $result = $src->show($ref, $path);
         if ('commit_directory' === $result['type']) {
@@ -154,6 +172,7 @@ class BitbucketClient implements GitClientInterface
     public function repoGetFileContent($repo, $path, $ref = null)
     {
         $src = new CustomSrc($this->client, $this->username, $repo);
+        $ref = $this->resolveRef($repo, $ref);
 
         $result = $src->show($ref, $path);
 

--- a/src/Components/GitLabClient.php
+++ b/src/Components/GitLabClient.php
@@ -6,23 +6,7 @@ use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use DreamFactory\Core\Git\Contracts\ClientInterface;
 use GrahamCampbell\GitLab\Auth\AuthenticatorFactory;
 use Gitlab\Client;
-use Gitlab\Api\Users;
 use Illuminate\Support\Arr;
-
-class CustomUsers extends Users
-{
-    /**
-     * @param int $id
-     * @param array $params
-     * @return mixed
-     */
-    public function usersProjects($id, array $params = [])
-    {
-        $resolver = $this->createOptionsResolver();
-
-        return $this->get('users/' . $this->encodePath($id) . '/projects', $resolver->resolve($params));
-    }
-}
 
 class GitLabClient implements ClientInterface
 {
@@ -32,6 +16,9 @@ class GitLabClient implements ClientInterface
 
     /** @var string */
     protected $namespace;
+
+    /** @var int|null */
+    protected $userId;
 
     /**
      * GitLabClient constructor.
@@ -58,6 +45,7 @@ class GitLabClient implements ClientInterface
                 throw new InternalServerErrorException('No authenticated user found for GitLab client. Please check GitLab service configuration.');
             }
             $namespace = $userInfo['username'];
+            $this->userId = isset($userInfo['id']) ? (int) $userInfo['id'] : null;
         }
         $this->namespace = $namespace;
     }
@@ -90,17 +78,20 @@ class GitLabClient implements ClientInterface
     /** {@inheritdoc} */
     public function repoAll($page = 1, $perPage = 50)
     {
-        $username = $this->client->users()->me()['username'];
+        $userInfo = $this->client->users()->me();
+        $username = $userInfo['username'] ?? null;
         $params = ['page' => (int)$page, 'per_page' => (int)$perPage];
 
         if ($username !== $this->namespace) {
             $groupList = $this->client->groups()->projects(rawurlencode($this->namespace), $params);
             return $groupList;
-        } else {
-            $cu = new CustomUsers($this->client);
-            $userList = $cu->usersProjects($username, $params);
-            return $userList;
         }
+
+        $userId = $this->userId ?? (isset($userInfo['id']) ? (int) $userInfo['id'] : null);
+        if ($userId === null) {
+            throw new InternalServerErrorException('Unable to determine GitLab user id for projects lookup.');
+        }
+        return $this->client->users()->usersProjects($userId, $params);
     }
 
     /** {@inheritdoc} */

--- a/src/Components/GitLabClient.php
+++ b/src/Components/GitLabClient.php
@@ -73,6 +73,23 @@ class GitLabClient implements ClientInterface
     }
 
     /**
+     * Falls back to the project's default branch when no ref is provided.
+     *
+     * @param string      $repo
+     * @param string|null $ref
+     *
+     * @return string
+     */
+    protected function resolveRef($repo, $ref)
+    {
+        if (!empty($ref)) {
+            return $ref;
+        }
+
+        return Arr::get($this->client->projects()->show($this->getProjectId($repo)), 'default_branch');
+    }
+
+    /**
      * @param $config
      *
      * @throws \DreamFactory\Core\Exceptions\InternalServerErrorException
@@ -114,7 +131,7 @@ class GitLabClient implements ClientInterface
     {
         $result = $this->repoList($repo, $path, $ref);
         if (0 === count($result)) {
-            $result = $this->client->repositoryFiles()->getFile($this->getProjectId($repo), $path, $ref);
+            $result = $this->client->repositoryFiles()->getFile($this->getProjectId($repo), $path, $this->resolveRef($repo, $ref));
             $result['path'] = $result['file_path'];
         }
 
@@ -124,7 +141,7 @@ class GitLabClient implements ClientInterface
     /** {@inheritdoc} */
     public function repoGetFileContent($repo, $path = null, $ref = null)
     {
-        return $this->client->repositoryFiles()->getRawFile($this->getProjectId($repo), $path, $ref);
+        return $this->client->repositoryFiles()->getRawFile($this->getProjectId($repo), $path, $this->resolveRef($repo, $ref));
     }
 
 }

--- a/src/Resources/BaseResource.php
+++ b/src/Resources/BaseResource.php
@@ -31,7 +31,7 @@ class BaseResource extends BaseRestResource
      */
     protected function handleGET()
     {
-        $branch = $this->request->getParameter('branch', $this->request->getParameter('tag', 'master'));
+        $branch = $this->request->getParameter('branch', $this->request->getParameter('tag'));
         $getContent = $this->request->getParameterAsBool('content');
         $asList = $this->request->getParameterAsBool(ApiOptions::AS_LIST);
         $fields = $this->request->getParameter(ApiOptions::FIELDS, '*');
@@ -125,6 +125,12 @@ class BaseResource extends BaseRestResource
                             'schema'      => ['type' => 'string'],
                             'description' => 'A file/folder path'
                         ],
+                        [
+                            'name'        => 'branch',
+                            'in'          => 'query',
+                            'schema'      => ['type' => 'string'],
+                            'description' => 'Branch or tag name. If omitted, the repository\'s default branch is used.'
+                        ],
                         ApiOptions::documentOption(ApiOptions::AS_LIST),
                     ],
                     'responses'   => [
@@ -157,6 +163,12 @@ class BaseResource extends BaseRestResource
                             'in'          => 'query',
                             'schema'      => ['type' => 'boolean'],
                             'description' => 'Set true to get file content',
+                        ],
+                        [
+                            'name'        => 'branch',
+                            'in'          => 'query',
+                            'schema'      => ['type' => 'string'],
+                            'description' => 'Branch or tag name. If omitted, the repository\'s default branch is used.'
                         ],
                     ],
                     'responses'   => [


### PR DESCRIPTION
7.7.0 release cut. Highlights: repository default-branch resolution (no more hardcoded master), upstream graham-campbell deps.

After merge, tag **0.9.0** on the merge commit (df-commercial's version refresh consumes the tags). Full release notes: see the 7.7.0 draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)